### PR TITLE
Added guidline to install libpq-dev package in the README

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -65,6 +65,11 @@ gem install bundler
 gem install rails
 ```
 
+Install libpq-dev package using
+```
+$sudo apt-get install libpq-dev
+```
+
 ### Project codebase.
 
 Download the mentor-mentee-platform code held in the GitHub Repository. 

--- a/server/README.md
+++ b/server/README.md
@@ -65,7 +65,7 @@ gem install bundler
 gem install rails
 ```
 
-Install libpq-dev package using
+(If you are using Ubuntu or Debian Linux:) Install the development package for the PostgreSQL database `libpq-dev` package using
 
 ```bash
 sudo apt-get install libpq-dev

--- a/server/README.md
+++ b/server/README.md
@@ -66,8 +66,9 @@ gem install rails
 ```
 
 Install libpq-dev package using
-```
-$sudo apt-get install libpq-dev
+
+```bash
+sudo apt-get install libpq-dev
 ```
 
 ### Project codebase.


### PR DESCRIPTION
"libpq-fe.h" header is part of libpq-dev package in Ubuntu. The header is required to install bundle successfully.