### PR TITLE
0609 heroku app crash

### DIFF
--- a/server/Procfile
+++ b/server/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}

--- a/server/app/controllers/api/v1/wishes_controller.rb
+++ b/server/app/controllers/api/v1/wishes_controller.rb
@@ -1,5 +1,5 @@
 require 'uri'
-require 'pry'
+#require 'pry'
 class Api::V1::WishesController < ApplicationController
   before_action :set_api_user
   before_action :set_api_user_wish, only: [:show, :update, :destroy]


### PR DESCRIPTION
App was crashing when deployed on Heroku,  removed a 'require pry' from wishes controller and now it is no longer crashing. 
I also added a Procfile to get rid of one of the warning messages that Heroku outputs when deploying app. 
@diwanow  hopefully with this change the automatic deployment will work. 