### PR TITLE
Dockerfile: include postgresql-client

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.6.5
 
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends nodejs libpq-dev
+    && apt-get install -y --no-install-recommends nodejs libpq-dev libxslt1-dev libffi-dev postgresql-client-common postgresql-client
 
 WORKDIR /app
 
@@ -15,4 +15,3 @@ CMD ./init_script.sh
 
 
 
- 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.6.5
 
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends nodejs libpq-dev libxslt1-dev libffi-dev postgresql-client-common postgresql-client
+    && apt-get install -y --no-install-recommends nodejs libpq-dev postgresql-client
 
 WORKDIR /app
 
@@ -12,6 +12,3 @@ RUN bundle install
 COPY . .
 
 CMD ./init_script.sh
-
-
-


### PR DESCRIPTION
@sibsmc I had errors while trying to run docker compose -up command:

`Installing pg 1.2.3 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/pg-1.2.3/ext
/usr/local/bin/ruby -I /usr/local/lib/ruby/2.6.0 -r
./siteconf20201010-6-1j9m960.rb extconf.rb
checking for pg_config... yes
Using config values from /usr/bin/pg_config
checking for libpq-fe.h... yes
checking for libpq/libpq-fs.h... yes
checking for pg_config_manual.h... yes
checking for PQconnectdb() in -lpq... no
checking for PQconnectdb() in -llibpq... no
checking for PQconnectdb() in -lms/libpq... no
Can't find the PostgreSQL client library (libpq)
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers. `

After adding libxslt1-dev libffi-dev postgresql-client-common postgresql-client, the command worked fine.

Can you please test? 