### PR TITLE
RuboCop configuration: show URL to a "style guide"

### DIFF
--- a/server/.rubocop.yml
+++ b/server/.rubocop.yml
@@ -6,6 +6,7 @@
 #so remember to ignore these rubocop results. 
 
 AllCops:
+  DisplayStyleGuide: true
   NewCops: enable
   Exclude:
     - 'bin/*'


### PR DESCRIPTION
When a rule makes a report about some code line, this setting makes it show a link to an article about that rule. This assists in learning about the Why of the rules being shown.