### PR TITLE
CI: Add GitHub Actions configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
-
+    env:
+      BUNDLE_GEMFILE: ./Gemfile
     strategy:
       matrix:
         ruby-version: [ 2.6.5 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ defaults:
 
 jobs:
   test:
-    env:
-      BUNDLE_GEMFILE: ./server/Gemfile
-
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Ruby CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# Ensure that the "Run test" and "Run RuboCop" steps are run within the 
+defaults:
+  run:
+    working-directory: ./server
+
+jobs:
+  test:
+    env:
+      BUNDLE_GEMFILE: ./server/Gemfile
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: [ 2.7 ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Run tests
+        run: bin/rails spec
+      - name: Linting
+        run: bundle exec rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+defaults:
+  run:
+    working-directory: ./server
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -24,10 +28,6 @@ jobs:
           BUNDLE_GEMFILE: ./server/Gemfile
 
       - name: Run tests
-        run: |
-          cd server
-          bin/rails spec
-      - name: Linting
-        run: |
-          cd server
-          bundle exec rubocop
+        run: bin/rails spec
+      - name: Run rubocop
+        run: bundle exec rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
-# Ensure that the "Run test" and "Run RuboCop" steps are run within the 
-defaults:
-  run:
-    working-directory: ./server
-
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: ./Gemfile
     strategy:
       matrix:
         ruby-version: [ 2.6.5 ]
@@ -27,8 +20,14 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        env:
+          BUNDLE_GEMFILE: ./server/Gemfile
 
       - name: Run tests
-        run: bin/rails spec
+        run: |
+          cd server
+          bin/rails spec
       - name: Linting
-        run: bundle exec rubocop
+        run: |
+          cd server
+          bundle exec rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [ 2.7 ]
+        ruby-version: [ 2.6.5 ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds a configuration file for GitHub Actions.

- Specify Ruby 2.6.5 exactly, so that it matches what is in the Gemfile.
- Point out what Gemfile to use when installing. Only then. Otherwise it's "Gemfile in this directory" as per normal.
- Set the working directory for all `run` Steps to be ./server, where the Rails files are.